### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/waveupHQ/smart-autonomous-assistants/security/code-scanning/1](https://github.com/waveupHQ/smart-autonomous-assistants/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block specifying the least privileges needed by the workflow. Since this workflow only needs to read repository contents to check out code, the minimal safe scope is `contents: read`. This can be set at the workflow root so it applies to all jobs that don’t override it.

Concretely, in `.github/workflows/ci.yml`, insert a `permissions:` section near the top of the file (for example after the `on:` block, or immediately below the `name:` line) with `contents: read`. No other permissions appear necessary given the current steps. No additional imports, methods, or other definitions are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
